### PR TITLE
fix: Update remaining display text to 0907095632

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -293,7 +293,7 @@ export default function Home() {
                 <Link href="tel:0907095632" className="w-full sm:w-auto">
                   <Button className="w-full text-lg h-12 px-8">
                     <Phone className="w-5 h-5 mr-2" />
-                    0933-118-656
+                    0907095632
                   </Button>
                 </Link>
               </div>


### PR DESCRIPTION
## Summary
- The `tel:` link on the homepage CTA (`app/page.tsx:293`) already pointed at `0907095632`, but the visible button text on line 296 still displayed the old number `0933-118-656`. This caused the deployed site to show the wrong number while the dial action used the new one.
- Updated the visible text so it matches the rest of the site.

## Test plan
- [ ] Visually verify the homepage CTA button shows `0907095632`
- [ ] Confirm tapping the button still dials `0907095632`
- [ ] Grep the repo for any remaining `0933` references (none expected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaH5E7oPY8E93pEpeeuKrS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the phone number displayed in the "Call Now" section to ensure customers can reach the correct contact line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->